### PR TITLE
Flexible shebang

### DIFF
--- a/get_site_log.py
+++ b/get_site_log.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 #      get_site_log.py
 #


### PR DESCRIPTION
Just one small suggestion for flexibility. 

The changed shebang uses the python interpreter found on the users path, and doesn't require python to be located at `/usr/bin/python`. 

Also, any reason for the as on Line 24 of `get_site_log.py`?

``` python
from classes import IGSLog as IGSLog
```
